### PR TITLE
Create user .config via /etc/skel

### DIFF
--- a/stage1/01-sys-tweaks/00-run.sh
+++ b/stage1/01-sys-tweaks/00-run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+install -d "${ROOTFS_DIR}/etc/skel/.config"
 
 install -d "${ROOTFS_DIR}/etc/systemd/system/getty@tty1.service.d"
 install -m 644 files/noclear.conf "${ROOTFS_DIR}/etc/systemd/system/getty@tty1.service.d/noclear.conf"


### PR DESCRIPTION
Early creation of the .config subdirectory in the users' home prevents incorrect ownership when raspi-config is invoked by the root user.
This resolves JanLahmann/RasQberry-Two#61.